### PR TITLE
Synchronize `pll_core_locked` into `clk_74a` domain before use

### DIFF
--- a/src/fpga/core/core_top.v
+++ b/src/fpga/core/core_top.v
@@ -332,10 +332,13 @@ module core_top (
   wire reset_n;  // driven by host commands, can be used as core-wide reset
   wire [31:0] cmd_bridge_rd_data;
 
+  wire pll_core_locked_s;
+  synch_3 s01(pll_core_locked, pll_core_locked_s, clk_74a);
+
   // bridge host commands
   // synchronous to clk_74a
-  wire status_boot_done = pll_core_locked;
-  wire status_setup_done = pll_core_locked;  // rising edge triggers a target command
+  wire status_boot_done = pll_core_locked_s;
+  wire status_setup_done = pll_core_locked_s;  // rising edge triggers a target command
   wire status_running = reset_n;  // we are running as soon as reset_n goes high
 
   wire dataslot_requestread;


### PR DESCRIPTION
The PLL `locked` output is not synchronous to its `refclk` input (see https://www.intel.com/content/www/us/en/docs/programmable/683359/17-0/pll-lock.html).