### PR TITLE
Make deployable out-of-box

### DIFF
--- a/dist/Cores/Developer.CoreTemplate/core.json
+++ b/dist/Cores/Developer.CoreTemplate/core.json
@@ -3,12 +3,12 @@
         "magic": "APF_VER_1",
         "metadata": {
             "platform_ids": ["ex_platform"],
-            "shortname": "Core Template",
+            "shortname": "CoreTemplate",
             "description": "APF core template. Displays gray test screen.",
             "author": "Developer",
-            "url": "https://github.com/open-fpga/core-template",
+            "url": "https://github.com/agg23/openfpga-template",
             "version": "1.1.0",
-            "date_release": "2022-08-23"
+            "date_release": "2023-02-28"
         },
         "framework": {
             "target_product": "Analogue Pocket",

--- a/dist/Cores/Developer.CoreTemplate/info.txt
+++ b/dist/Cores/Developer.CoreTemplate/info.txt
@@ -1,3 +1,5 @@
 Example Core - Core Template
 
 This is a template for a core containing all of the core definition JSON files and FPGA starter code.
+
+Forked by agg23

--- a/dist/Platforms/ex_platform.json
+++ b/dist/Platforms/ex_platform.json
@@ -1,0 +1,8 @@
+{
+  "platform": {
+    "category": "Example Cores",
+    "name": "Example Platform",
+    "year": 2022,
+    "manufacturer": "Example Manufacturer"
+  }
+}


### PR DESCRIPTION
At the moment, once dist/ is built this repo cannot be directly deployed to a Pocket because there is no platform.json and core.json has a typo in the Cores directory name.

I fixed these problems, I also amended info.txt and core.json slightly to indicate this is the agg23 template and not the original template. (The added sentence in info.txt could be worded however you want, however, because I do sometimes deploy the core template or slight variations on them to devices for tests, this would help me keep track of which cores are based on the agg23 template and which on the analogue template.)

In addition, I think it would help to add a sentence or two to the README explaining the core can be deployed by building, reversing the rbf to bitstream.rbf_r, and rsyncing to the device. This is not a big deal however and may be covered in your wiki somewhere already. I could write proposal text for this if it would help, though.